### PR TITLE
Backfill missing lab metadata (13 files)

### DIFF
--- a/Instructions/Labs/0-Setup/0-LAB-SETUP.md
+++ b/Instructions/Labs/0-Setup/0-LAB-SETUP.md
@@ -1,3 +1,13 @@
+---
+lab:
+  title: Lab Setup
+  description: Complete the following tasks to prepare your development environment
+    prior to completing the labs.
+  duration: 42 minutes
+  level: 200
+  islab: true
+---
+
 # Lab Setup
 
 Complete the following tasks to prepare your development environment prior to completing the labs.

--- a/Instructions/Labs/1-Get-started-teams-toolkit/1-1-Install-setup-teams-toolkit.md
+++ b/Instructions/Labs/1-Get-started-teams-toolkit/1-1-Install-setup-teams-toolkit.md
@@ -1,3 +1,16 @@
+---
+lab:
+  title: 'Exercise 1: Install and set up Teams Toolkit for Visual Studio Code'
+  description: In this exercise, you'll install Teams Toolkit for Visual Studio Code
+    and set up your environment.
+  duration: 30 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Visual Studio
+  - Visual Studio Code
+---
+
 # Exercise 1: Install and set up Teams Toolkit for Visual Studio Code
 
 In this exercise, you'll install Teams Toolkit for Visual Studio Code and set up your environment.

--- a/Instructions/Labs/1-Get-started-teams-toolkit/2-Create-a-teams-app.md
+++ b/Instructions/Labs/1-Get-started-teams-toolkit/2-Create-a-teams-app.md
@@ -1,3 +1,18 @@
+---
+lab:
+  title: 'Exercise 2: Create a Teams app using Teams Toolkit'
+  description: Teams Toolkit for Visual Studio Code offers two methods for creating
+    a new app. You can create a new app using the built-in templates provided by the
+    toolkit. Additionally, Teams Toolkit for Visual Studio Code also provides a collection
+    of samples that are ready for you to explore and create your base app from.
+  duration: 32 minutes
+  level: 100
+  islab: true
+  primarytopics:
+  - Visual Studio
+  - Visual Studio Code
+---
+
 # Exercise 2: Create a Teams app using Teams Toolkit
 
 Teams Toolkit for Visual Studio Code offers two methods for creating a new app. You can create a new app using the built-in templates provided by the toolkit. Additionally, Teams Toolkit for Visual Studio Code also provides a collection of samples that are ready for you to explore and create your base app from. 

--- a/Instructions/Labs/1-Get-started-teams-toolkit/3-Run-your-Teams-app.md
+++ b/Instructions/Labs/1-Get-started-teams-toolkit/3-Run-your-Teams-app.md
@@ -1,3 +1,12 @@
+---
+lab:
+  title: 'Exercise 3: Run your Teams app'
+  description: In this exercise you will run the Teams app locally.
+  duration: 36 minutes
+  level: 100
+  islab: true
+---
+
 # Exercise 3: Run your Teams app
 
 In this exercise you will run the Teams app locally.

--- a/Instructions/Labs/2-Deploy-microsoft-teams-app/1-Create-Azure-resources.md
+++ b/Instructions/Labs/2-Deploy-microsoft-teams-app/1-Create-Azure-resources.md
@@ -1,3 +1,18 @@
+---
+lab:
+  title: 'Exercise 1: Create Azure resources to host a Teams tab app'
+  description: In this exercise, you'll first create and provision a Teams tab app
+    by using Teams Toolkit for Visual Studio Code. In a later exercise, you'll set
+    up the app to be hosted in Azure.
+  duration: 58 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Azure
+  - Visual Studio
+  - Visual Studio Code
+---
+
 # Exercise 1: Create Azure resources to host a Teams tab app
 
 In this exercise, you'll first create and provision a Teams tab app by using Teams Toolkit for Visual Studio Code. In a later exercise, you'll set up the app to be hosted in Azure.

--- a/Instructions/Labs/2-Deploy-microsoft-teams-app/2-Deploy-source-code.md
+++ b/Instructions/Labs/2-Deploy-microsoft-teams-app/2-Deploy-source-code.md
@@ -1,3 +1,15 @@
+---
+lab:
+  title: 'Exercise 2: Deploy your app''s source code'
+  description: In this exercise, you deploy the source code to your provisioned Azure
+    resources.
+  duration: 20 minutes
+  level: 200
+  islab: true
+  primarytopics:
+  - Azure
+---
+
 # Exercise 2: Deploy your app's source code
 
 In this exercise, you deploy the source code to your provisioned Azure resources.

--- a/Instructions/Labs/2-Deploy-microsoft-teams-app/3-Publish-Teams-app.md
+++ b/Instructions/Labs/2-Deploy-microsoft-teams-app/3-Publish-Teams-app.md
@@ -1,3 +1,13 @@
+---
+lab:
+  title: 'Exercise 3: Publish your Teams tab app'
+  description: In this exercise, you learn how to publish your app to the organization
+    store.
+  duration: 40 minutes
+  level: 100
+  islab: true
+---
+
 # Exercise 3: Publish your Teams tab app
 
 In this exercise, you learn how to publish your app to the organization store.

--- a/Instructions/Labs/3-Guided-project/2-Exercise-1.md
+++ b/Instructions/Labs/3-Guided-project/2-Exercise-1.md
@@ -1,7 +1,18 @@
 ---
 lab:
-    title: 'Implement a message extension that retrieves data from Microsoft Graph'
-    module: 'Exercise 1'
+  title: Implement a message extension that retrieves data from Microsoft Graph
+  module: Exercise 1
+  description: Suppose you have been asked to help the IT Support team build a message
+    extension that allows team members to retrieve contact information for users and
+    insert the contact details into messages in Teams using cards.  In this exercise,
+    you will implement a message extension that retrieves user data from Microsoft
+    Graph.  The solution has already been scaffolded using Teams Toolkit, but you
+    will need to make changes to implement functionality.
+  duration: 25 minutes
+  level: 300
+  islab: true
+  primarytopics:
+  - Microsoft Graph
 ---
 
 # Exercise 1: Implement a message extension that retrieves data from Microsoft Graph

--- a/Instructions/Labs/3-Guided-project/3-Exercise 2.md
+++ b/Instructions/Labs/3-Guided-project/3-Exercise 2.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Create an Incoming Webhook'
-    module: 'Exercise 2'
+  title: Create an Incoming Webhook
+  module: Exercise 2
+  description: Suppose the IT Support team uses a third-party notification service
+    to manage alerts and messages. Recently, the team decided to automate the process
+    of posting messages to a Teams channel that is used for critical updates.  The
+    third-party service is being designed to post messages via a webhook.
+  duration: 8 minutes
+  level: 200
+  islab: true
 ---
 
 # Exercise 2: Create an Incoming Webhook

--- a/Instructions/Labs/3-Guided-project/4-Exercise 3.md
+++ b/Instructions/Labs/3-Guided-project/4-Exercise 3.md
@@ -1,7 +1,15 @@
 ---
 lab:
-    title: 'Create a Teams Tab'
-    module: 'Exercise 3'
+  title: Create a Teams Tab
+  module: Exercise 3
+  description: Suppose the IT Support team wants to create a Teams tab to help users
+    access necessary information when submitting support tickets. For example, the
+    team needs to display users' locale codes for ticket processing and reporting.
+    Your current task is to create this tab to display a user's locale code. Additional
+    information will be added to the tab at a later date.
+  duration: 10 minutes
+  level: 100
+  islab: true
 ---
 
 # Exercise 3: Create a Teams Tab

--- a/Instructions/Labs/3-Guided-project/5-Exercise 4.md
+++ b/Instructions/Labs/3-Guided-project/5-Exercise 4.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Build a Bot'
-    module: 'Exercise 4'
+  title: Build a Bot
+  module: Exercise 4
+  description: Suppose the IT Support team you are supporting receives a high volume
+    of common, repetitive queries from employees across the organization. These queries
+    often involve simple issues like password resets, software installation instructions,
+    or troubleshooting common errors.
+  duration: 17 minutes
+  level: 300
+  islab: true
 ---
 
 # Exercise 4: Build a Bot

--- a/Instructions/Labs/3-Guided-project/6-Exercise 5.md
+++ b/Instructions/Labs/3-Guided-project/6-Exercise 5.md
@@ -1,7 +1,15 @@
 ---
 lab:
-    title: 'Build a Bot with AI'
-    module: 'Exercise 4'
+  title: Build a Bot with AI
+  module: Exercise 4
+  description: Imagine you're a member of the IT Support team. You realize that compiling
+    the Weekly Report is a very mechanical and time-consuming process. You wish to
+    create an AI bot within MS Teams. By simply discussing the weekly work items and
+    tasks for the upcoming week with the bot in a conversation, it can generate a
+    well-formatted weekly report. This could significantly improve work efficiency.
+  duration: 20 minutes
+  level: 300
+  islab: true
 ---
 
 # Exercise 4: Build a Bot with AI

--- a/Instructions/Labs/3-Guided-project/7-Exercise 6.md
+++ b/Instructions/Labs/3-Guided-project/7-Exercise 6.md
@@ -1,7 +1,14 @@
 ---
 lab:
-    title: 'Build a Basic Bot'
-    module: 'Exercise 6'
+  title: Build a Basic Bot
+  module: Exercise 6
+  description: Suppose you have been asked to help the IT Support team build a Teams
+    bot. This bot will have the capability to retrieve the abbreviation for a given
+    state and also fetch the current weather conditions for a specific area based
+    on its ZIP Code.
+  duration: 15 minutes
+  level: 200
+  islab: true
 ---
 
 # Exercise 6: Build a Basic Bot


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 13

- `Instructions/Labs/0-Setup/0-LAB-SETUP.md` (front_matter_created,normalized_case_keys,title,description,duration,level,islab)
- `Instructions/Labs/1-Get-started-teams-toolkit/1-1-Install-setup-teams-toolkit.md` (front_matter_created,normalized_case_keys,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/1-Get-started-teams-toolkit/2-Create-a-teams-app.md` (front_matter_created,normalized_case_keys,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/1-Get-started-teams-toolkit/3-Run-your-Teams-app.md` (front_matter_created,normalized_case_keys,title,description,duration,level,islab)
- `Instructions/Labs/2-Deploy-microsoft-teams-app/1-Create-Azure-resources.md` (front_matter_created,normalized_case_keys,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/2-Deploy-microsoft-teams-app/2-Deploy-source-code.md` (front_matter_created,normalized_case_keys,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/2-Deploy-microsoft-teams-app/3-Publish-Teams-app.md` (front_matter_created,normalized_case_keys,title,description,duration,level,islab)
- `Instructions/Labs/3-Guided-project/2-Exercise-1.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/3-Guided-project/3-Exercise 2.md` (description,duration,level,islab)
- `Instructions/Labs/3-Guided-project/4-Exercise 3.md` (description,duration,level,islab)
- `Instructions/Labs/3-Guided-project/5-Exercise 4.md` (description,duration,level,islab)
- `Instructions/Labs/3-Guided-project/6-Exercise 5.md` (description,duration,level,islab)
- `Instructions/Labs/3-Guided-project/7-Exercise 6.md` (description,duration,level,islab)
