### PR TITLE
Backfill missing lab metadata (11 files)

### DIFF
--- a/Instructions/Labs/1-Get-started-teams-toolkit/2-Create-a-teams-app.md
+++ b/Instructions/Labs/1-Get-started-teams-toolkit/2-Create-a-teams-app.md
@@ -1,3 +1,14 @@
+---
+lab:
+  title: 'Exercise 2: Create a Teams app using Teams Toolkit'
+  description: In this exercise, you'll create your first Microsoft Teams app using the built-in templates.
+  duration: 32 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Microsoft Teams
+---
+
 # Exercise 2: Create a Teams app using Teams Toolkit
 
 Teams Toolkit for Visual Studio Code offers two methods for creating a new app. You can create a new app using the built-in templates provided by the toolkit. Additionally, Teams Toolkit for Visual Studio Code also provides a collection of samples that are ready for you to explore and create your base app from. 

--- a/Instructions/Labs/1-Get-started-teams-toolkit/3-Run-your-Teams-app.md
+++ b/Instructions/Labs/1-Get-started-teams-toolkit/3-Run-your-Teams-app.md
@@ -1,3 +1,12 @@
+---
+lab:
+  title: 'Exercise 3: Run your Teams app'
+  description: In this exercise you will run the Teams app locally.
+  duration: 36 minutes
+  level: 100
+  islab: true
+---
+
 # Exercise 3: Run your Teams app
 
 In this exercise you will run the Teams app locally.

--- a/Instructions/Labs/2-Deploy-microsoft-teams-app/1-Create-Azure-resources.md
+++ b/Instructions/Labs/2-Deploy-microsoft-teams-app/1-Create-Azure-resources.md
@@ -1,3 +1,16 @@
+---
+lab:
+  title: 'Exercise 1: Create Azure resources to host a Teams tab app'
+  description: In this exercise, you'll first create and provision a Teams tab app by using Teams Toolkit for Visual Studio Code. In a later exercise, you'll set up the app to be hosted in Azure.
+  duration: 58 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Azure
+    - Visual Studio
+    - Visual Studio Code
+---
+
 # Exercise 1: Create Azure resources to host a Teams tab app
 
 In this exercise, you'll first create and provision a Teams tab app by using Teams Toolkit for Visual Studio Code. In a later exercise, you'll set up the app to be hosted in Azure.

--- a/Instructions/Labs/2-Deploy-microsoft-teams-app/2-Deploy-source-code.md
+++ b/Instructions/Labs/2-Deploy-microsoft-teams-app/2-Deploy-source-code.md
@@ -1,3 +1,14 @@
+---
+lab:
+  title: 'Exercise 2: Deploy your app''s source code'
+  description: In this exercise, you deploy the source code to your provisioned Azure resources.
+  duration: 20 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Azure
+---
+
 # Exercise 2: Deploy your app's source code
 
 In this exercise, you deploy the source code to your provisioned Azure resources.

--- a/Instructions/Labs/2-Deploy-microsoft-teams-app/3-Publish-Teams-app.md
+++ b/Instructions/Labs/2-Deploy-microsoft-teams-app/3-Publish-Teams-app.md
@@ -1,3 +1,12 @@
+---
+lab:
+  title: 'Exercise 3: Publish your Teams tab app'
+  description: In this exercise, you learn how to publish your app to the organization store.
+  duration: 40 minutes
+  level: 100
+  islab: true
+---
+
 # Exercise 3: Publish your Teams tab app
 
 In this exercise, you learn how to publish your app to the organization store.

--- a/Instructions/Labs/3-Guided-project/2-Exercise-1.md
+++ b/Instructions/Labs/3-Guided-project/2-Exercise-1.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Implement a message extension that retrieves data from Microsoft Graph'
-    module: 'Exercise 1'
+  title: Implement a message extension that retrieves data from Microsoft Graph
+  module: Exercise 1
+  description: Suppose you have been asked to help the IT Support team build a message extension that allows team members to retrieve contact information for users and insert the contact details into messages in Teams using cards. In this exercise, you will implement a message extension that retrieves user data from Microsoft Graph. The solution has already been scaffolded using Teams Toolkit, but you will need to make changes to implement functionality.
+  duration: 25 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Microsoft Graph
 ---
 
 # Exercise 1: Implement a message extension that retrieves data from Microsoft Graph

--- a/Instructions/Labs/3-Guided-project/3-Exercise 2.md
+++ b/Instructions/Labs/3-Guided-project/3-Exercise 2.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Create an Incoming Webhook'
-    module: 'Exercise 2'
+  title: Create an Incoming Webhook
+  module: Exercise 2
+  description: Your task is to create a new Incoming Webhook, named Alerts, to receive these messages. You should also test the webhook to ensure it can accept and display a message with the string "Testing the Alerts endpoint." correctly. The team will update the service with the webhook endpoint URL when you complete your tasks.
+  duration: 8 minutes
+  level: 200
+  islab: true
 ---
 
 # Exercise 2: Create an Incoming Webhook

--- a/Instructions/Labs/3-Guided-project/4-Exercise 3.md
+++ b/Instructions/Labs/3-Guided-project/4-Exercise 3.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Create a Teams Tab'
-    module: 'Exercise 3'
+  title: Create a Teams Tab
+  module: Exercise 3
+  description: 'You will need to complete the following tasks to complete the exercise:'
+  duration: 10 minutes
+  level: 100
+  islab: true
 ---
 
 # Exercise 3: Create a Teams Tab

--- a/Instructions/Labs/3-Guided-project/5-Exercise 4.md
+++ b/Instructions/Labs/3-Guided-project/5-Exercise 4.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Build a Bot'
-    module: 'Exercise 4'
+  title: Build a Bot
+  module: Exercise 4
+  description: 'Use the Command Bot template to create a new bot:'
+  duration: 17 minutes
+  level: 300
+  islab: true
 ---
 
 # Exercise 4: Build a Bot

--- a/Instructions/Labs/3-Guided-project/6-Exercise 5.md
+++ b/Instructions/Labs/3-Guided-project/6-Exercise 5.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Build a Bot with AI'
-    module: 'Exercise 4'
+  title: Build a Bot with AI
+  module: Exercise 4
+  description: Imagine you're a member of the IT Support team. You realize that compiling the Weekly Report is a very mechanical and time-consuming process. You wish to create an AI bot within MS Teams. By simply discussing the weekly work items and tasks for the upcoming week with the bot in a conversation, it can generate a well-formatted weekly report. This could significantly improve work efficiency.
+  duration: 20 minutes
+  level: 300
+  islab: true
 ---
 
 # Exercise 4: Build a Bot with AI

--- a/Instructions/Labs/3-Guided-project/7-Exercise 6.md
+++ b/Instructions/Labs/3-Guided-project/7-Exercise 6.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Build a Basic Bot'
-    module: 'Exercise 6'
+  title: Build a Basic Bot
+  module: Exercise 6
+  description: In this exercise, you will use the Teams Toolkit template to create a simple Teams bot. This bot will utilize the Teams AI library to process messages with users and include interactions using Adaptive Cards. Please note that this exercise does not involve interactions between the Teams AI library and LLMs.
+  duration: 15 minutes
+  level: 200
+  islab: true
 ---
 
 # Exercise 6: Build a Basic Bot


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 11

- `Instructions/Labs/1-Get-started-teams-toolkit/2-Create-a-teams-app.md` (front_matter_created,lab_mapping_created,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/1-Get-started-teams-toolkit/3-Run-your-Teams-app.md` (front_matter_created,lab_mapping_created,title,description,duration,level,islab)
- `Instructions/Labs/2-Deploy-microsoft-teams-app/1-Create-Azure-resources.md` (front_matter_created,lab_mapping_created,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/2-Deploy-microsoft-teams-app/2-Deploy-source-code.md` (front_matter_created,lab_mapping_created,title,description,duration,level,islab,primarytopics)
- `Instructions/Labs/2-Deploy-microsoft-teams-app/3-Publish-Teams-app.md` (front_matter_created,lab_mapping_created,title,description,duration,level,islab)
- `Instructions/Labs/3-Guided-project/2-Exercise-1.md` (description,duration,level,islab,primarytopics)
- `Instructions/Labs/3-Guided-project/3-Exercise 2.md` (description,duration,level,islab)
- `Instructions/Labs/3-Guided-project/4-Exercise 3.md` (description,duration,level,islab)
- `Instructions/Labs/3-Guided-project/5-Exercise 4.md` (description,duration,level,islab)
- `Instructions/Labs/3-Guided-project/6-Exercise 5.md` (description,duration,level,islab)
- `Instructions/Labs/3-Guided-project/7-Exercise 6.md` (description,duration,level,islab)
